### PR TITLE
fix: evaluate specific flags, topo sort before evaluate

### DIFF
--- a/pkg/experiment/local/sort.go
+++ b/pkg/experiment/local/sort.go
@@ -12,7 +12,7 @@ func topologicalSort(flags map[string]interface{}, flagKeys []string) ([]interfa
 		available[k] = v
 	}
 	// Get the starting keys
-	startingKeys := make([]string, 0)
+	var startingKeys []string
 	if len(flagKeys) > 0 {
 		startingKeys = flagKeys
 	} else {
@@ -56,7 +56,6 @@ func parentTraversal(flagKey string, available map[string]interface{}, path []st
 		}
 	}
 	result = append(result, flag)
-	path = path[:len(path)-1]
 	delete(available, flagKey)
 	return result, nil
 }
@@ -77,7 +76,7 @@ func extractDependencies(flag interface{}) []string {
 			switch flags := flagsAny.(type) {
 			case map[string]interface{}:
 				result := make([]string, 0)
-				for k, _ := range flags {
+				for k := range flags {
 					result = append(result, k)
 				}
 				return result

--- a/pkg/experiment/local/sort.go
+++ b/pkg/experiment/local/sort.go
@@ -1,0 +1,88 @@
+package local
+
+import "fmt"
+
+func topologicalSort(flags map[string]interface{}, flagKeys []string) ([]interface{}, error) {
+	result := make([]interface{}, 0)
+	// Extract keys and copy flags map
+	keys := make([]string, 0)
+	available := make(map[string]interface{})
+	for k, v := range flags {
+		keys = append(keys, k)
+		available[k] = v
+	}
+	// Get the starting keys
+	startingKeys := make([]string, 0)
+	if len(flagKeys) > 0 {
+		startingKeys = flagKeys
+	} else {
+		startingKeys = keys
+	}
+	// Sort into result
+	for _, flagKey := range startingKeys {
+		traversal, err := parentTraversal(flagKey, available, []string{})
+		if err != nil {
+			return nil, err
+		}
+		if len(traversal) > 0 {
+			result = append(result, traversal...)
+		}
+	}
+	return result, nil
+}
+
+func parentTraversal(flagKey string, available map[string]interface{}, path []string) ([]interface{}, error) {
+	flag := available[flagKey]
+	if flag == nil {
+		return nil, nil
+	}
+	dependencies := extractDependencies(flag)
+	if len(dependencies) == 0 {
+		delete(available, flagKey)
+		return []interface{}{flag}, nil
+	}
+	path = append(path, flagKey)
+	result := make([]interface{}, 0)
+	for _, parentKey := range dependencies {
+		if contains(path, parentKey) {
+			return nil, fmt.Errorf("detected a cycle between flags %v", path)
+		}
+		traversal, err := parentTraversal(parentKey, available, path)
+		if err != nil {
+			return nil, err
+		}
+		if len(traversal) > 0 {
+			result = append(result, traversal...)
+		}
+	}
+	result = append(result, flag)
+	path = path[:len(path)-1]
+	delete(available, flagKey)
+	return result, nil
+}
+
+func extractDependencies(flag interface{}) []string {
+	switch f := flag.(type) {
+	case map[string]interface{}:
+		parentDependenciesAny := f["parentDependencies"]
+		if parentDependenciesAny == nil {
+			return nil
+		}
+		switch parentDependencies := parentDependenciesAny.(type) {
+		case map[string]interface{}:
+			flagsAny := parentDependencies["flags"]
+			if flagsAny == nil {
+				return nil
+			}
+			switch flags := flagsAny.(type) {
+			case map[string]interface{}:
+				result := make([]string, 0)
+				for k, _ := range flags {
+					result = append(result, k)
+				}
+				return result
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/experiment/local/sort_test.go
+++ b/pkg/experiment/local/sort_test.go
@@ -1,0 +1,435 @@
+package local
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEmpty(t *testing.T) {
+	// No flag keys
+	{
+		inputFlags := flagsArray()
+		inputFlagKeys := make([]string, 0)
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag keys
+	{
+		inputFlags := flagsArray()
+		inputFlagKeys := []string{"1"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+}
+
+func TestSingleFlagNoDependencies(t *testing.T) {
+	// No flag keys
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{}})
+		inputFlagKeys := make([]string, 0)
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(flag{Key: "1", Dependencies: []string{}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag keys
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{}})
+		inputFlagKeys := []string{"1"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(flag{Key: "1", Dependencies: []string{}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag no match
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{}})
+		inputFlagKeys := []string{"999"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+}
+
+func TestSingleFlagWithDependencies(t *testing.T) {
+	// No flag keys
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{"2"}})
+		inputFlagKeys := make([]string, 0)
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(flag{Key: "1", Dependencies: []string{"2"}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag keys
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{"2"}})
+		inputFlagKeys := []string{"1"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(flag{Key: "1", Dependencies: []string{"2"}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag no match
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{"2"}})
+		inputFlagKeys := []string{"999"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+}
+func TestMultipleFlagsNoDependencies(t *testing.T) {
+	// No flag keys
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{}},
+			flag{Key: "2", Dependencies: []string{}})
+		inputFlagKeys := make([]string, 0)
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(
+			flag{Key: "1", Dependencies: []string{}},
+			flag{Key: "2", Dependencies: []string{}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag keys
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{}},
+			flag{Key: "2", Dependencies: []string{}})
+		inputFlagKeys := []string{"1", "2"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(
+			flag{Key: "1", Dependencies: []string{}},
+			flag{Key: "2", Dependencies: []string{}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag no match
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{}},
+			flag{Key: "2", Dependencies: []string{}})
+		inputFlagKeys := []string{"99", "999"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+}
+func TestMultipleFlagWithDependencies(t *testing.T) {
+	// No flag keys
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{"2"}},
+			flag{Key: "2", Dependencies: []string{"3"}},
+			flag{Key: "3", Dependencies: []string{}})
+		inputFlagKeys := make([]string, 0)
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(
+			flag{Key: "3", Dependencies: []string{}},
+			flag{Key: "2", Dependencies: []string{"3"}},
+			flag{Key: "1", Dependencies: []string{"2"}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag keys
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{"2"}},
+			flag{Key: "2", Dependencies: []string{"3"}},
+			flag{Key: "3", Dependencies: []string{}})
+		inputFlagKeys := []string{"1", "2"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray(
+			flag{Key: "3", Dependencies: []string{}},
+			flag{Key: "2", Dependencies: []string{"3"}},
+			flag{Key: "1", Dependencies: []string{"2"}})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+	// With flag no match
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{"2"}},
+			flag{Key: "2", Dependencies: []string{"3"}},
+			flag{Key: "3", Dependencies: []string{}})
+		inputFlagKeys := []string{"999"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+}
+func TestSingleFlagCycle(t *testing.T) {
+	// No flag keys
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{"1"}})
+		inputFlagKeys := make([]string, 0)
+		_, err := topologicalSortArray(inputFlags, inputFlagKeys)
+		if err == nil {
+			t.Fatalf("expected cycle error")
+		}
+	}
+	// With flag keys
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{"1"}})
+		inputFlagKeys := []string{"1"}
+		_, err := topologicalSortArray(inputFlags, inputFlagKeys)
+		if err == nil {
+			t.Fatalf("expected cycle error")
+		}
+
+	}
+	// With flag no match
+	{
+		inputFlags := flagsArray(flag{Key: "1", Dependencies: []string{"1"}})
+		inputFlagKeys := []string{"999"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+}
+func TestTwoFlagCycle(t *testing.T) {
+	// No flag keys
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{"2"}},
+			flag{Key: "2", Dependencies: []string{"1"}})
+		inputFlagKeys := make([]string, 0)
+		_, err := topologicalSortArray(inputFlags, inputFlagKeys)
+		if err == nil {
+			t.Fatalf("expected cycle error")
+		}
+	}
+	// With flag keys
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{"2"}},
+			flag{Key: "2", Dependencies: []string{"1"}})
+		inputFlagKeys := []string{"2"}
+		_, err := topologicalSortArray(inputFlags, inputFlagKeys)
+		if err == nil {
+			t.Fatalf("expected cycle error")
+		}
+	}
+	// With flag no match
+	{
+		inputFlags := flagsArray(
+			flag{Key: "1", Dependencies: []string{"2"}},
+			flag{Key: "2", Dependencies: []string{"1"}})
+		inputFlagKeys := []string{"999"}
+		actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+		expected := flagsArray()
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, actual %v", expected, actual)
+		}
+	}
+}
+func TestMultipleFlagsComplexCycle(t *testing.T) {
+	inputFlags := flagsArray(
+		flag{Key: "3", Dependencies: []string{"1", "2"}},
+		flag{Key: "1", Dependencies: []string{}},
+		flag{Key: "4", Dependencies: []string{"21", "3"}},
+		flag{Key: "2", Dependencies: []string{}},
+		flag{Key: "5", Dependencies: []string{"3"}},
+		flag{Key: "6", Dependencies: []string{}},
+		flag{Key: "7", Dependencies: []string{}},
+		flag{Key: "8", Dependencies: []string{"9"}},
+		flag{Key: "9", Dependencies: []string{}},
+		flag{Key: "20", Dependencies: []string{"4"}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+	)
+	inputFlagKeys := make([]string, 0)
+	_, err := topologicalSortArray(inputFlags, inputFlagKeys)
+	if err == nil {
+		t.Fatalf("expected cycle error")
+	}
+}
+func TestComplexNoCycleStartingWithLeaf(t *testing.T) {
+	inputFlags := flagsArray(
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+		flag{Key: "2", Dependencies: []string{"8", "5", "3", "1"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "9", Dependencies: []string{"10", "7", "5"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "20", Dependencies: []string{}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+		flag{Key: "30", Dependencies: []string{}},
+	)
+	inputFlagKeys := make([]string, 0)
+	actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+	expected := flagsArray(
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+		flag{Key: "2", Dependencies: []string{"8", "5", "3", "1"}},
+		flag{Key: "9", Dependencies: []string{"10", "7", "5"}},
+		flag{Key: "20", Dependencies: []string{}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+		flag{Key: "30", Dependencies: []string{}},
+	)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %v, actual %v", expected, actual)
+	}
+}
+func TestComplexNoCycleStartingWithMiddle(t *testing.T) {
+	inputFlags := flagsArray(
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+		flag{Key: "2", Dependencies: []string{"8", "5", "3", "1"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "9", Dependencies: []string{"10", "7", "5"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "20", Dependencies: []string{}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+		flag{Key: "30", Dependencies: []string{}},
+	)
+	inputFlagKeys := make([]string, 0)
+	actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+	expected := flagsArray(
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+		flag{Key: "2", Dependencies: []string{"8", "5", "3", "1"}},
+		flag{Key: "9", Dependencies: []string{"10", "7", "5"}},
+		flag{Key: "20", Dependencies: []string{}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+		flag{Key: "30", Dependencies: []string{}},
+	)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %v, actual %v", expected, actual)
+	}
+}
+func TestComplexNoCycleStartingWithRoot(t *testing.T) {
+	inputFlags := flagsArray(
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+		flag{Key: "2", Dependencies: []string{"8", "5", "3", "1"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "9", Dependencies: []string{"10", "7", "5"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "20", Dependencies: []string{}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+		flag{Key: "30", Dependencies: []string{}},
+	)
+	inputFlagKeys := make([]string, 0)
+	actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+	expected := flagsArray(
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+		flag{Key: "2", Dependencies: []string{"8", "5", "3", "1"}},
+		flag{Key: "9", Dependencies: []string{"10", "7", "5"}},
+		flag{Key: "20", Dependencies: []string{}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+		flag{Key: "30", Dependencies: []string{}},
+	)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %v, actual %v", expected, actual)
+	}
+}
+
+// Utilities
+
+type flag struct {
+	Key          string
+	Dependencies []string
+}
+
+func flagsArray(flags ...flag) []interface{} {
+	result := make([]interface{}, 0)
+	for _, f := range flags {
+		result = append(result, flagInterface(f))
+	}
+	return result
+}
+
+func flagInterface(flag flag) interface{} {
+	dependencyMap := make(map[string]interface{})
+	for _, dependency := range flag.Dependencies {
+		dependencyMap[dependency] = true
+	}
+	return map[string]interface{}{
+		"flagKey": flag.Key,
+		"parentDependencies": map[string]interface{}{
+			"flags": dependencyMap,
+		},
+	}
+}
+
+// Used for testing to ensure the correct ordering of iteration.
+func topologicalSortArray(flags []interface{}, flagKeys []string) ([]interface{}, error) {
+	// Extract keys and create flags map
+	keys := make([]string, 0)
+	available := make(map[string]interface{})
+	for _, flagAny := range flags {
+		switch flag := flagAny.(type) {
+		case map[string]interface{}:
+			switch flagKey := flag["flagKey"].(type) {
+			case string:
+				keys = append(keys, flagKey)
+				available[flagKey] = flag
+			}
+		}
+	}
+	// Get the starting keys
+	startingKeys := make([]string, 0)
+	if len(flagKeys) > 0 {
+		startingKeys = flagKeys
+	} else {
+		startingKeys = keys
+	}
+	return topologicalSort(available, startingKeys)
+}

--- a/pkg/experiment/local/sort_test.go
+++ b/pkg/experiment/local/sort_test.go
@@ -381,6 +381,39 @@ func TestComplexNoCycleStartingWithRoot(t *testing.T) {
 	}
 }
 
+func TestComplexNoCycleWithFlagKeys(t *testing.T) {
+	inputFlags := flagsArray(
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+		flag{Key: "2", Dependencies: []string{"8", "5", "3", "1"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "9", Dependencies: []string{"10", "7", "5"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "20", Dependencies: []string{}},
+		flag{Key: "21", Dependencies: []string{"20"}},
+		flag{Key: "30", Dependencies: []string{}},
+	)
+	inputFlagKeys := []string{"1"}
+	actual, _ := topologicalSortArray(inputFlags, inputFlagKeys)
+	expected := flagsArray(
+		flag{Key: "8", Dependencies: []string{}},
+		flag{Key: "7", Dependencies: []string{"8"}},
+		flag{Key: "4", Dependencies: []string{"8", "7"}},
+		flag{Key: "6", Dependencies: []string{"7", "4"}},
+		flag{Key: "10", Dependencies: []string{"7"}},
+		flag{Key: "5", Dependencies: []string{"10", "7"}},
+		flag{Key: "3", Dependencies: []string{"6", "5"}},
+		flag{Key: "1", Dependencies: []string{"6", "3"}},
+	)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %v, actual %v", expected, actual)
+	}
+}
+
 // Utilities
 
 type flag struct {

--- a/pkg/experiment/local/sort_test.go
+++ b/pkg/experiment/local/sort_test.go
@@ -425,7 +425,7 @@ func topologicalSortArray(flags []interface{}, flagKeys []string) ([]interface{}
 		}
 	}
 	// Get the starting keys
-	startingKeys := make([]string, 0)
+	var startingKeys []string
 	if len(flagKeys) > 0 {
 		startingKeys = flagKeys
 	} else {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Golang Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Only evaluate requested flags after topological sort

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-go-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
