### PR TITLE
fix: Do not track empty assignment events

### DIFF
--- a/pkg/experiment/local/assignment_filter.go
+++ b/pkg/experiment/local/assignment_filter.go
@@ -19,6 +19,9 @@ func newAssignmentFilter(size int) *assignmentFilter {
 }
 
 func (f *assignmentFilter) shouldTrack(assignment *assignment) bool {
+	if len(*assignment.results) == 0 {
+		return false
+	}
 	canonicalAssignment := assignment.Canonicalize()
 	f.mu.Lock()
 	track, found := f.cache.Get(canonicalAssignment)

--- a/pkg/experiment/local/assignment_filter_test.go
+++ b/pkg/experiment/local/assignment_filter_test.go
@@ -167,13 +167,13 @@ func TestEmptyResult(t *testing.T) {
 	assignment2 := newAssignment(user1, results)
 	assignment3 := newAssignment(user2, results)
 	filter := newAssignmentFilter(100)
-	if !filter.shouldTrack(assignment1) {
+	if filter.shouldTrack(assignment1) {
 		t.Errorf("Assignment1 should be tracked")
 	}
 	if filter.shouldTrack(assignment2) {
 		t.Errorf("Assignment2 should not be tracked")
 	}
-	if !filter.shouldTrack(assignment3) {
+	if filter.shouldTrack(assignment3) {
 		t.Errorf("Assignment3 should be tracked")
 	}
 }

--- a/pkg/experiment/local/assignment_filter_test.go
+++ b/pkg/experiment/local/assignment_filter_test.go
@@ -168,13 +168,13 @@ func TestEmptyResult(t *testing.T) {
 	assignment3 := newAssignment(user2, results)
 	filter := newAssignmentFilter(100)
 	if filter.shouldTrack(assignment1) {
-		t.Errorf("Assignment1 should be tracked")
+		t.Errorf("Assignment1 should not be tracked")
 	}
 	if filter.shouldTrack(assignment2) {
 		t.Errorf("Assignment2 should not be tracked")
 	}
 	if filter.shouldTrack(assignment3) {
-		t.Errorf("Assignment3 should be tracked")
+		t.Errorf("Assignment3 should not be tracked")
 	}
 }
 


### PR DESCRIPTION
### Summary

Employ fix: empty assignment events are not tracked

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-go-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
