### PR TITLE
feat: add method to access flag metadata

### DIFF
--- a/pkg/experiment/local/client.go
+++ b/pkg/experiment/local/client.go
@@ -147,6 +147,23 @@ func (c *Client) FlagsV2() (string, error) {
 	return flagsString, nil
 }
 
+// FlagMetadata returns a copy of the flag's metadata. If the flag is not found then nil is returned.
+func (c *Client) FlagMetadata(flagKey string) map[string]interface{} {
+	c.flagsMutex.RLock()
+	f := c.flags[flagKey]
+	c.flagsMutex.RUnlock()
+	if f == nil {
+		return nil
+	}
+
+	metadata := make(map[string]interface{})
+	for k, v := range f.Metadata {
+		metadata[k] = v
+	}
+
+	return metadata
+}
+
 func (c *Client) doFlagsV2() (map[string]*evaluation.Flag, error) {
 	client := &http.Client{}
 	endpoint, err := url.Parse("https://api.lab.amplitude.com/")

--- a/pkg/experiment/local/client_test.go
+++ b/pkg/experiment/local/client_test.go
@@ -143,3 +143,17 @@ func TestEvaluateV2UnknownFlagKey(t *testing.T) {
 		t.Fatalf("Unexpected variant %v", variant)
 	}
 }
+
+func TestFlagMetadataUnknownFlagKey(t *testing.T) {
+	md := client.FlagMetadata("does-not-exist")
+	if md != nil {
+		t.Fatalf("Unexpected metadata %v", md)
+	}
+}
+
+func TestFlagMetadataLocalFlagKey(t *testing.T) {
+	md := client.FlagMetadata("sdk-local-evaluation-ci-test")
+	if md["evaluationMode"] != "local" {
+		t.Fatalf("Unexpected metadata %v", md)
+	}
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Golang Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
Exposes a method to retrieve a flag's metadata. This is useful for being able to know whether a flag should be evaluated locally or remotely.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-go-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
