### PR TITLE
feat(remote.Client): Add current context to Fetch and FetchV2

### DIFF
--- a/pkg/experiment/remote/client.go
+++ b/pkg/experiment/remote/client.go
@@ -62,11 +62,11 @@ func (c *Client) Fetch(user *experiment.User) (map[string]experiment.Variant, er
 // Unlike Fetch, this method returns all variants, including default variants.
 func (c *Client) FetchV2(user *experiment.User) (map[string]experiment.Variant, error) {
 	ctx := context.Background()
-	return c.FetchV2WithContext(ctx, user)
+	return c.FetchV2WithContext(user, ctx)
 }
 
 // FetchV2WithContext fetches variants for a user from the remote evaluation service with a context.
-func (c *Client) FetchV2WithContext(ctx context.Context, user *experiment.User) (map[string]experiment.Variant, error) {
+func (c *Client) FetchV2WithContext(user *experiment.User, ctx context.Context) (map[string]experiment.Variant, error) {
 	variants, err := c.doFetch(ctx, user, c.config.FetchTimeout)
 	if err != nil {
 		c.log.Error("fetch error: %v", err)

--- a/pkg/experiment/remote/client.go
+++ b/pkg/experiment/remote/client.go
@@ -49,8 +49,8 @@ func Initialize(apiKey string, config *Config) *Client {
 }
 
 // Deprecated: Use FetchV2
-func (c *Client) Fetch(ctx context.Context, user *experiment.User) (map[string]experiment.Variant, error) {
-	variants, err := c.FetchV2(ctx, user)
+func (c *Client) Fetch(user *experiment.User) (map[string]experiment.Variant, error) {
+	variants, err := c.FetchV2(user)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,13 @@ func (c *Client) Fetch(ctx context.Context, user *experiment.User) (map[string]e
 
 // FetchV2 fetches variants for a user from the remote evaluation service.
 // Unlike Fetch, this method returns all variants, including default variants.
-func (c *Client) FetchV2(ctx context.Context, user *experiment.User) (map[string]experiment.Variant, error) {
+func (c *Client) FetchV2(user *experiment.User) (map[string]experiment.Variant, error) {
+	ctx := context.Background()
+	return c.FetchV2WithContext(ctx, user)
+}
+
+// FetchV2WithContext fetches variants for a user from the remote evaluation service with a context.
+func (c *Client) FetchV2WithContext(ctx context.Context, user *experiment.User) (map[string]experiment.Variant, error) {
 	variants, err := c.doFetch(ctx, user, c.config.FetchTimeout)
 	if err != nil {
 		c.log.Error("fetch error: %v", err)

--- a/pkg/experiment/remote/client.go
+++ b/pkg/experiment/remote/client.go
@@ -39,9 +39,16 @@ func Initialize(apiKey string, config *Config) *Client {
 			log:    logger.New(config.Debug),
 			apiKey: apiKey,
 			config: config,
-			client: &http.Client{},
 		}
+
+		if config.HttpClient != nil {
+			client.client = config.HttpClient
+		} else {
+			client.client = &http.Client{}
+		}
+
 		client.log.Debug("config: %v", *config)
+		clients[apiKey] = client
 	}
 	initMutex.Unlock()
 	return client

--- a/pkg/experiment/remote/client_test.go
+++ b/pkg/experiment/remote/client_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -14,19 +15,20 @@ import (
 
 func TestClient_Fetch_DoesNotReturnDefaultVariants(t *testing.T) {
 	client := Initialize("server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz", nil)
+	ctx := context.Background()
 	user := &experiment.User{}
-	result, err := client.Fetch(user)
+	result, err := client.Fetch(ctx, user)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	variant := result["sdk-ci-test"]
 	require.Empty(t, variant)
 }
 
-
 func TestClient_FetchV2_ReturnsDefaultVariants(t *testing.T) {
 	client := Initialize("server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz", nil)
+	ctx := context.Background()
 	user := &experiment.User{}
-	result, err := client.FetchV2(user)
+	result, err := client.FetchV2(ctx, user)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	variant := result["sdk-ci-test"]
@@ -47,6 +49,8 @@ func TestClient_FetchRetryWithDifferentResponseCodes(t *testing.T) {
 		{500, "Fetch Exception 500", 2},
 		{0, "Other Exception", 2},
 	}
+
+	ctx := context.Background()
 
 	for _, data := range testData {
 		// Mock client initialization with httptest
@@ -92,7 +96,7 @@ func TestClient_FetchRetryWithDifferentResponseCodes(t *testing.T) {
 		fmt.Printf("%d %s\n", data.responseCode, data.errorMessage)
 
 		// Perform the fetch and catch the exception
-		_, err := client.Fetch(&experiment.User{UserId: "test_user"})
+		_, err := client.Fetch(ctx, &experiment.User{UserId: "test_user"})
 		if err != nil {
 			fmt.Println(err.Error())
 		}

--- a/pkg/experiment/remote/client_test.go
+++ b/pkg/experiment/remote/client_test.go
@@ -1,7 +1,6 @@
 package remote
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,9 +14,8 @@ import (
 
 func TestClient_Fetch_DoesNotReturnDefaultVariants(t *testing.T) {
 	client := Initialize("server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz", nil)
-	ctx := context.Background()
 	user := &experiment.User{}
-	result, err := client.Fetch(ctx, user)
+	result, err := client.Fetch(user)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	variant := result["sdk-ci-test"]
@@ -26,9 +24,8 @@ func TestClient_Fetch_DoesNotReturnDefaultVariants(t *testing.T) {
 
 func TestClient_FetchV2_ReturnsDefaultVariants(t *testing.T) {
 	client := Initialize("server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz", nil)
-	ctx := context.Background()
 	user := &experiment.User{}
-	result, err := client.FetchV2(ctx, user)
+	result, err := client.FetchV2(user)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	variant := result["sdk-ci-test"]
@@ -49,8 +46,6 @@ func TestClient_FetchRetryWithDifferentResponseCodes(t *testing.T) {
 		{500, "Fetch Exception 500", 2},
 		{0, "Other Exception", 2},
 	}
-
-	ctx := context.Background()
 
 	for _, data := range testData {
 		// Mock client initialization with httptest
@@ -96,7 +91,7 @@ func TestClient_FetchRetryWithDifferentResponseCodes(t *testing.T) {
 		fmt.Printf("%d %s\n", data.responseCode, data.errorMessage)
 
 		// Perform the fetch and catch the exception
-		_, err := client.Fetch(ctx, &experiment.User{UserId: "test_user"})
+		_, err := client.Fetch(&experiment.User{UserId: "test_user"})
 		if err != nil {
 			fmt.Println(err.Error())
 		}

--- a/pkg/experiment/remote/config.go
+++ b/pkg/experiment/remote/config.go
@@ -1,7 +1,6 @@
 package remote
 
 import (
-	"net/http"
 	"time"
 )
 
@@ -10,7 +9,6 @@ type Config struct {
 	ServerUrl    string
 	FetchTimeout time.Duration
 	RetryBackoff *RetryBackoff
-	HttpClient   *http.Client
 }
 
 var DefaultConfig = &Config{
@@ -18,7 +16,6 @@ var DefaultConfig = &Config{
 	ServerUrl:    "https://api.lab.amplitude.com/",
 	FetchTimeout: 500 * time.Millisecond,
 	RetryBackoff: DefaultRetryBackoff,
-	HttpClient:   nil,
 }
 
 type RetryBackoff struct {

--- a/pkg/experiment/remote/config.go
+++ b/pkg/experiment/remote/config.go
@@ -1,12 +1,16 @@
 package remote
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 type Config struct {
 	Debug        bool
 	ServerUrl    string
 	FetchTimeout time.Duration
 	RetryBackoff *RetryBackoff
+	HttpClient   *http.Client
 }
 
 var DefaultConfig = &Config{
@@ -14,6 +18,7 @@ var DefaultConfig = &Config{
 	ServerUrl:    "https://api.lab.amplitude.com/",
 	FetchTimeout: 500 * time.Millisecond,
 	RetryBackoff: DefaultRetryBackoff,
+	HttpClient:   nil,
 }
 
 type RetryBackoff struct {


### PR DESCRIPTION
### Summary

~~Add a field in the Config type to provide the internal http.Client the remote.Client is going to use.~~

~~No breaking changes. Same default behaviour as before.~~

~~Allow instrumenting remote http calls providing a wrapped http.Client.~~

Pass the current Context to `Fetch` and `FetchV2` to enable distributed tracing.

Fixes #28 

### Checklist

* [ x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-go-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* ~~Does your PR have a breaking change?:  No~~
* Does your PR have a breaking change?:  Yes
