### PR TITLE
style: format json outputs

### DIFF
--- a/cmd/xpmt/main.go
+++ b/cmd/xpmt/main.go
@@ -98,7 +98,7 @@ func fetch() {
 	}
 	duration := time.Since(start)
 	fmt.Println(duration)
-	b, _ := json.Marshal(variants)
+	b, _ := json.MarshalIndent(variants, "", "  ")
 	fmt.Printf("%v\n", string(b))
 }
 
@@ -227,6 +227,6 @@ func evaluate() {
 		return
 	}
 
-	b, _ := json.Marshal(variants)
+	b, _ := json.MarshalIndent(variants, "", "  ")
 	fmt.Printf("%v\n", string(b))
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Golang Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This pull request introduces formatting improvements to the JSON outputs displayed in the terminal, and suggests to use 2-space indentation

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-go-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
