### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
     name: Lint
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.17'
           check-latest: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           version: latest
   test:
@@ -29,9 +29,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Setup
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.17'
           check-latest: true

--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -12,7 +12,7 @@ jobs:
     name: SDK Bot Jira Issue Creation
     steps:
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -20,7 +20,7 @@ jobs:
 
       - name: Create issue
         id: create
-        uses: atlassian/gajira-create@master
+        uses: atlassian/gajira-create@1ff0b6bd115a780592b47bfbb63fc4629132e6ec # v3
         with:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: Task

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
       with:
         go-version: '1.17'
         check-latest: true
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '22'
 


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via automated scripts.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 2026-04-10.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow changes only pin existing GitHub Action references to immutable commit SHAs; runtime behavior should remain the same aside from fetching a specific action revision.
> 
> **Overview**
> Pins GitHub Actions used by CI workflows to full commit SHAs for supply-chain hardening.
> 
> Updates `build.yml`, `release.yml`, and `jira-issue-create.yml` to replace floating tags/branches (e.g., `@v3`, `@v4`, `@master`) with specific commit hashes for `actions/checkout`, `actions/setup-go`, `actions/setup-node`, `golangci-lint-action`, and Atlassian Jira actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a0762917e7c53830d4e8f65e9e5318bc6233baa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->