### PR TITLE
feat: support multi-value array properties for non-set operators

### DIFF
--- a/internal/evaluation/engine.go
+++ b/internal/evaluation/engine.go
@@ -90,24 +90,28 @@ func (e *Engine) evaluateSegment(target *target, flag *Flag, segment *Segment) *
 
 func (e *Engine) matchCondition(target *target, condition *Condition) bool {
 	propValue := selectEach(target, condition.Selector)
-	// We need special matching for null properties and set type prop values
-	// and operators. All other values are matched as strings, since the
-	// filter values are always strings.
 	if propValue == nil {
 		return matchNull(condition.Op, condition.Values)
-	} else if isSetOperator(condition.Op) {
-		propValueStringList, err := coerceStringList(propValue)
-		if err != nil {
+	}
+	// coerceStringList is called for every non-null value so non-set
+	// operators can match any element of an array/JSON-array-string
+	// (matches analytics/charts any-element semantics). A nil list means
+	// the value is not list-like; fall through to the scalar path.
+	propValueStringList, _ := coerceStringList(propValue)
+	if isSetOperator(condition.Op) {
+		if propValueStringList == nil {
 			return false
 		}
 		return matchSet(propValueStringList, condition.Op, condition.Values)
-	} else {
-		propValueString := coerceString(propValue)
-		if propValueString == nil {
-			return false
-		}
-		return matchString(*propValueString, condition.Op, condition.Values)
 	}
+	if propValueStringList != nil {
+		return matchStringsNonSet(propValueStringList, condition.Op, condition.Values)
+	}
+	propValueString := coerceString(propValue)
+	if propValueString == nil {
+		return false
+	}
+	return matchString(*propValueString, condition.Op, condition.Values)
 }
 
 func (e *Engine) getHash(key string) uint64 {
@@ -225,6 +229,19 @@ func matchString(propValue string, op string, filterValues []string) bool {
 	default:
 		return false
 	}
+}
+
+// matchStringsNonSet returns true if any element in propValues satisfies
+// the non-set operator against filterValues. Negation operators (is not,
+// does not contain) also use any-match — true if any single element
+// satisfies the negation — matching analytics/charts behavior.
+func matchStringsNonSet(propValues []string, op string, filterValues []string) bool {
+	for _, v := range propValues {
+		if matchString(v, op, filterValues) {
+			return true
+		}
+	}
+	return false
 }
 
 func matchesIs(propValue string, filterValues []string) bool {
@@ -485,6 +502,12 @@ func coerceStringList(value interface{}) ([]string, error) {
 		// Parse a string as json array and convert to list of strings, or
 		// return null if the string could not be parsed as a json array.
 		stringValue := fmt.Sprintf("%v", value)
+		// Cheap pre-check: avoid exception-driven control flow when the
+		// value is clearly not a JSON array. This runs for every non-null
+		// value now that non-set operators also consult coerceStringList.
+		if !strings.HasPrefix(stringValue, "[") {
+			return nil, nil
+		}
 		var stringList []string
 		err := json.Unmarshal([]byte(stringValue), &stringList)
 		if err != nil {

--- a/internal/evaluation/engine_test.go
+++ b/internal/evaluation/engine_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 )
 
-const deploymentKey = "server-NgJxxvg8OGwwBsWVXqyxQbdiflbhvugy"
+const deploymentKey = "server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh"
 
 var flags []*Flag
 var engine = &Engine{logger.New(false)}
@@ -731,6 +731,95 @@ func TestSetDoesNotContainAny(t *testing.T) {
 	}
 }
 
+// Multi-value array property support — integration tests against the
+// VVhLULX deployment. Collection and JSON-array-string shapes of the
+// same property should match equivalently on both set and non-set
+// operators.
+
+func TestSetIsWithJsonArrayString(t *testing.T) {
+	user := userContext(map[string]interface{}{
+		"user_properties": map[string]interface{}{
+			"key": `["1", "2", "3"]`,
+		},
+	})
+	result := engine.Evaluate(user, flags)["test-set-is"]
+	if result.Key != "on" {
+		t.Fatalf("unexpected evaluation result %v", result.Key)
+	}
+}
+
+func TestIsArrayCollection(t *testing.T) {
+	user := userContext(map[string]interface{}{
+		"user_properties": map[string]interface{}{
+			"key": []string{"value1", "value2"},
+		},
+	})
+	result := engine.Evaluate(user, flags)["test-is-array"]
+	if result.Key != "on" {
+		t.Fatalf("unexpected evaluation result %v", result.Key)
+	}
+}
+
+func TestIsNotArrayCollection(t *testing.T) {
+	user := userContext(map[string]interface{}{
+		"user_properties": map[string]interface{}{
+			"key": []string{"value3", "value4"},
+		},
+	})
+	result := engine.Evaluate(user, flags)["test-is-not-array"]
+	if result.Key != "on" {
+		t.Fatalf("unexpected evaluation result %v", result.Key)
+	}
+}
+
+func TestContainsArrayCollection(t *testing.T) {
+	user := userContext(map[string]interface{}{
+		"user_properties": map[string]interface{}{
+			"key": []string{"has-target-value", "has", "value"},
+		},
+	})
+	result := engine.Evaluate(user, flags)["test-contains-array"]
+	if result.Key != "on" {
+		t.Fatalf("unexpected evaluation result %v", result.Key)
+	}
+}
+
+func TestDoesNotContainArrayCollection(t *testing.T) {
+	user := userContext(map[string]interface{}{
+		"user_properties": map[string]interface{}{
+			"key": []string{"has-value", "has", "value"},
+		},
+	})
+	result := engine.Evaluate(user, flags)["test-does-not-contain-array"]
+	if result.Key != "on" {
+		t.Fatalf("unexpected evaluation result %v", result.Key)
+	}
+}
+
+func TestIsArrayJsonString(t *testing.T) {
+	user := userContext(map[string]interface{}{
+		"user_properties": map[string]interface{}{
+			"key": `["value1", "value2"]`,
+		},
+	})
+	result := engine.Evaluate(user, flags)["test-is-array"]
+	if result.Key != "on" {
+		t.Fatalf("unexpected evaluation result %v", result.Key)
+	}
+}
+
+func TestDoesNotContainArrayJsonString(t *testing.T) {
+	user := userContext(map[string]interface{}{
+		"user_properties": map[string]interface{}{
+			"key": `["has-value", "has", "value"]`,
+		},
+	})
+	result := engine.Evaluate(user, flags)["test-does-not-contain-array"]
+	if result.Key != "on" {
+		t.Fatalf("unexpected evaluation result %v", result.Key)
+	}
+}
+
 func TestGlobMatch(t *testing.T) {
 	user := userContext(map[string]interface{}{
 		"user_properties": map[string]interface{}{
@@ -790,6 +879,44 @@ func TestIsWithBooleans(t *testing.T) {
 	}
 }
 
+// Multi-value array property support — unit tests driven by an inline
+// flag/condition harness (no remote dependency). Covers scalar, list, and
+// JSON-array-string shapes across set and non-set operators.
+
+func TestMultiValueArrayMatching(t *testing.T) {
+	cases := []struct {
+		name    string
+		propVal interface{}
+		op      string
+		values  []string
+		match   bool
+	}{
+		{"scalar string IS match", "hello", OpIs, []string{"hello"}, true},
+		{"scalar string CONTAINS match", "hello", OpContains, []string{"ell"}, true},
+		{"scalar string GREATER match", "2", OpGreaterThan, []string{"1"}, true},
+		{"scalar string IS no match", "world", OpIs, []string{"hello"}, false},
+		{"non-string scalar GREATER", 42, OpGreaterThan, []string{"1"}, true},
+		{"non-string scalar IS bool", true, OpIs, []string{"true"}, true},
+		{"JSON array string + set contains", `["a","b"]`, OpSetContains, []string{"a"}, true},
+		{"JSON array string + non-set IS", `["a","b"]`, OpIs, []string{"a"}, true},
+		{"collection + set contains", []string{"a", "b"}, OpSetContains, []string{"a"}, true},
+		{"collection + non-set IS", []string{"a", "b"}, OpIs, []string{"a"}, true},
+		{"malformed JSON falls through", "[broken", OpIs, []string{"[broken"}, true},
+		{"empty JSON array + set contains", "[]", OpSetContains, []string{"a"}, false},
+		{"leading whitespace non-set IS", ` ["a"]`, OpIs, []string{` ["a"]`}, true},
+		{"leading whitespace set contains", ` ["a"]`, OpSetContains, []string{"a"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.match {
+				assertMatch(t, tc.propVal, tc.op, tc.values)
+			} else {
+				assertNoMatch(t, tc.propVal, tc.op, tc.values)
+			}
+		})
+	}
+}
+
 // Util
 
 func userContext(u map[string]interface{}) map[string]interface{} {
@@ -798,6 +925,57 @@ func userContext(u map[string]interface{}) map[string]interface{} {
 
 func groupContext(g map[string]interface{}) map[string]interface{} {
 	return map[string]interface{}{"groups": g}
+}
+
+// flagWithCondition builds a minimal flag with a single segment, condition
+// group, and condition targeting context.user.user_properties.test_prop.
+func flagWithCondition(op string, values []string) *Flag {
+	return &Flag{
+		Key:      "test-flag",
+		Variants: map[string]*Variant{"on": {Key: "on"}},
+		Segments: []*Segment{
+			{
+				Conditions: [][]*Condition{{
+					{
+						Selector: []string{"context", "user", "user_properties", "test_prop"},
+						Op:       op,
+						Values:   values,
+					},
+				}},
+				Variant: "on",
+			},
+		},
+	}
+}
+
+func contextWithProp(value interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"user": map[string]interface{}{
+			"user_properties": map[string]interface{}{
+				"test_prop": value,
+			},
+		},
+	}
+}
+
+func evaluateProp(propValue interface{}, op string, values []string) string {
+	flag := flagWithCondition(op, values)
+	ctx := contextWithProp(propValue)
+	return engine.Evaluate(ctx, []*Flag{flag})["test-flag"].Key
+}
+
+func assertMatch(t *testing.T, propValue interface{}, op string, values []string) {
+	t.Helper()
+	if k := evaluateProp(propValue, op, values); k != "on" {
+		t.Fatalf("expected match but got key=%q for propValue=%v op=%q values=%v", k, propValue, op, values)
+	}
+}
+
+func assertNoMatch(t *testing.T, propValue interface{}, op string, values []string) {
+	t.Helper()
+	if k := evaluateProp(propValue, op, values); k == "on" {
+		t.Fatalf("expected no match but got key=%q for propValue=%v op=%q values=%v", k, propValue, op, values)
+	}
 }
 
 func getFlagConfigsRaw() ([]byte, error) {


### PR DESCRIPTION
## Summary

Non-set operators (`is`, `contains`, `greater`, etc.) previously coerced array/list properties to a single JSON-stringified value, diverging from analytics/charts behavior where any element of an array can satisfy the condition.

- `matchCondition` now consults `coerceStringList` for every non-null value and dispatches to a new `matchStringsNonSet` helper when the value coerces to a list — **any-match** semantics, including for negation operators (`is not`, `does not contain`), which match if any single element satisfies the negation.
- `coerceStringList` gains a `strings.HasPrefix(s, "[")` pre-check so scalar strings skip JSON parsing now that every value passes through it.
- User-visible consequence: JSON-array strings with **leading whitespace** (e.g., `" [\"a\"]"`) are no longer parsed as arrays by set operators.

## Test plan

- [x] Inline flag/condition harness drives 14 evaluation-engine unit cases (scalar / collection / JSON-array-string × set and non-set operators)
- [x] 7 integration tests against the superset deployment (`server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh`)
- [x] Pre-existing evaluation tests unchanged (segment-name assertions still match the superset deployment)
- [x] `go vet ./...` clean
- [x] `go test ./internal/evaluation/...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag condition matching semantics so non-set operators (`is`, `contains`, comparisons, regex) can match any element of an array/JSON-array-string, which could change targeting results for existing flags. Also tightens JSON-array-string detection (`HasPrefix("[")`), which may stop parsing arrays with leading whitespace for set operators.
> 
> **Overview**
> Updates `matchCondition` so **non-set operators** evaluate array-like properties (slices/arrays or JSON-array-strings) using *any-element* semantics via new `matchStringsNonSet`, instead of coercing the whole value to a single string.
> 
> Adds a fast `HasPrefix("[")` guard in `coerceStringList` to avoid unnecessary JSON parsing now that list coercion runs for all non-null properties, and expands tests with both remote integration cases and an inline flag/condition harness to cover scalar vs multi-value behavior (including negation and whitespace edge cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33ed5e9b92cc7f1d12e964c84b3b0603f11f96d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->