### PR TITLE
fix: include experiment key on local-eval exposure events

### DIFF
--- a/pkg/experiment/local/exposure_service.go
+++ b/pkg/experiment/local/exposure_service.go
@@ -68,6 +68,9 @@ func toExposureEvents(exposure *exposure, ttlMillis int64) []amplitude.Event {
 		} else if variant.Value != "" {
 			eventProperties["[Experiment] Variant"] = variant.Value
 		}
+		if experimentKey, ok := variant.Metadata["experimentKey"].(string); ok && experimentKey != "" {
+			eventProperties["[Experiment] Experiment Key"] = experimentKey
+		}
 		if variant.Metadata != nil {
 			eventProperties["metadata"] = variant.Metadata
 		}

--- a/pkg/experiment/local/exposure_service_test.go
+++ b/pkg/experiment/local/exposure_service_test.go
@@ -76,14 +76,25 @@ func TestToExposureEvents(t *testing.T) {
 			Value: "on",
 		},
 		"empty_variant": {},
+		"with_experiment_key": {
+			Key:   "treatment",
+			Value: "treatment",
+			Metadata: map[string]interface{}{
+				"segmentName":   "All Other Users",
+				"flagType":      "experiment",
+				"flagVersion":   float64(10),
+				"default":       false,
+				"experimentKey": "exp-1",
+			},
+		},
 	}
 
 	exposure := newExposure(user, results)
 	events := toExposureEvents(exposure, dayMillis)
 	// Should exclude default (default=true) only
-	// basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant = 7 events
-	if len(events) != 7 {
-		t.Errorf("Expected 7 events, got %d", len(events))
+	// basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant, with_experiment_key = 8 events
+	if len(events) != 8 {
+		t.Errorf("Expected 8 events, got %d", len(events))
 	}
 
 	for _, event := range events {
@@ -109,6 +120,17 @@ func TestToExposureEvents(t *testing.T) {
 		if variant.Metadata != nil {
 			if !reflect.DeepEqual(event.EventProperties["metadata"], variant.Metadata) {
 				t.Errorf("Metadata mismatch")
+			}
+		}
+
+		// Validate experiment key is lifted to top-level event property when present
+		if flagKey == "with_experiment_key" {
+			if event.EventProperties["[Experiment] Experiment Key"] != "exp-1" {
+				t.Errorf("Expected [Experiment] Experiment Key to be exp-1, got %v", event.EventProperties["[Experiment] Experiment Key"])
+			}
+		} else {
+			if _, present := event.EventProperties["[Experiment] Experiment Key"]; present {
+				t.Errorf("[Experiment] Experiment Key should be absent for flag %s", flagKey)
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Local evaluation exposure events from `toExposureEvents` carried `experimentKey` only inside the `metadata` blob — the top-level event property `[Experiment] Experiment Key` was never set, so custom reports keying off it saw no value for local-eval customers.
- Fix: when `variant.Metadata["experimentKey"]` is a non-empty string, set `EventProperties["[Experiment] Experiment Key"]`. Additive and backwards-compatible — `metadata`, `[Experiment] Flag Key`, `[Experiment] Variant`, user properties, and `InsertID` are unchanged.
- Mirrors [amplitude/experiment-node-server#83](https://github.com/amplitude/experiment-node-server/pull/83).

## Test plan

- [x] Added `with_experiment_key` fixture to `TestToExposureEvents`. Asserts `[Experiment] Experiment Key` equals `"exp-1"` for that flag and is absent for the others.
- [x] Updated event count expectation accordingly.
- [x] `go test ./pkg/experiment/local/ -run TestToExposureEvents -v` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive change that only sets an extra event property when `variant.Metadata["experimentKey"]` is present; existing event fields and filtering behavior are unchanged.
> 
> **Overview**
> Local evaluation exposure tracking now *lifts* `variant.Metadata["experimentKey"]` into a top-level Amplitude event property (`[Experiment] Experiment Key`) in `toExposureEvents`, instead of leaving it only inside the `metadata` blob.
> 
> Tests were updated with a `with_experiment_key` fixture to assert the new property is set only when provided, and the expected event count was adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbd125605d309de3c96661a825a097a982a25d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->