### PR TITLE
fix: use server url for base path

### DIFF
--- a/pkg/experiment/local/client.go
+++ b/pkg/experiment/local/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"reflect"
 	"sync"
 
@@ -209,7 +210,7 @@ func (c *Client) doFlagsV2() (map[string]*evaluation.Flag, error) {
 	if err != nil {
 		return nil, err
 	}
-	endpoint.Path = "sdk/v2/flags"
+	endpoint.Path = path.Join(endpoint.Path, "sdk/v2/flags")
 	endpoint.RawQuery = "v=0"
 	ctx, cancel := context.WithTimeout(context.Background(), c.config.FlagConfigPollerRequestTimeout)
 	defer cancel()
@@ -252,7 +253,7 @@ func (c *Client) doRules() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	endpoint.Path = "sdk/rules"
+	endpoint.Path = path.Join(endpoint.Path, "sdk/rules")
 	endpoint.RawQuery = "eval_mode=local"
 	ctx, cancel := context.WithTimeout(context.Background(), c.config.FlagConfigPollerRequestTimeout)
 	defer cancel()
@@ -306,7 +307,7 @@ func (c *Client) doFlags() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	endpoint.Path = "sdk/v1/flags"
+	endpoint.Path = path.Join(endpoint.Path, "sdk/v1/flags")
 	ctx, cancel := context.WithTimeout(context.Background(), c.config.FlagConfigPollerRequestTimeout)
 	defer cancel()
 	req, err := http.NewRequest("GET", endpoint.String(), nil)

--- a/pkg/experiment/local/flag_config_api.go
+++ b/pkg/experiment/local/flag_config_api.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 
 	"github.com/amplitude/experiment-go-server/internal/evaluation"
@@ -37,7 +38,7 @@ func (a *flagConfigApiV2) getFlagConfigs() (map[string]*evaluation.Flag, error) 
 	if err != nil {
 		return nil, err
 	}
-	endpoint.Path = "sdk/v2/flags"
+	endpoint.Path = path.Join(endpoint.Path, "sdk/v2/flags")
 	endpoint.RawQuery = "v=0"
 	ctx, cancel := context.WithTimeout(context.Background(), a.FlagConfigPollerRequestTimeoutMillis)
 	defer cancel()

--- a/pkg/experiment/local/flag_config_stream_api.go
+++ b/pkg/experiment/local/flag_config_stream_api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/url"
+	"path"
 	"sync"
 	"time"
 
@@ -69,7 +70,7 @@ func (api *flagConfigStreamApiV2) Connect(
 	if err != nil {
 		return err
 	}
-	endpoint.Path = "sdk/stream/v1/flags"
+	endpoint.Path = path.Join(endpoint.Path, "sdk/stream/v1/flags")
 
 	// Create Stream.
 	stream := api.newSseStreamFactory("Api-Key "+api.DeploymentKey, endpoint.String(), api.connectionTimeout, streamApiKeepaliveTimeout, streamApiReconnInterval, streamApiMaxJitter)

--- a/pkg/experiment/remote/client.go
+++ b/pkg/experiment/remote/client.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"path"
 	"sync"
 	"time"
 
@@ -96,7 +97,7 @@ func (c *Client) doFetch(ctx context.Context, user *experiment.User, timeout tim
 	if err != nil {
 		return nil, err
 	}
-	endpoint.Path = "sdk/v2/vardata"
+	endpoint.Path = path.Join(endpoint.Path, "sdk/v2/vardata")
 	if c.config.Debug {
 		endpoint.RawQuery = fmt.Sprintf("d=%s", randStringRunes(5))
 	}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Golang Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

fix: use server url for base path, doesn't use url.JoinPath because of go 1.17

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-go-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All outbound experiment API URLs change when a non-root path is configured; mis-joined paths could break fetches until URLs are validated, but the change is small and targeted.
> 
> **Overview**
> HTTP clients no longer **replace** the entire URL path when building Amplitude SDK routes. They use `path.Join` on the parsed base URL’s existing path and the SDK segment (`sdk/v2/flags`, `sdk/rules`, `sdk/v1/flags`, `sdk/stream/v1/flags`, `sdk/v2/vardata`).
> 
> This applies to **local** flag polling/streaming and deprecated rules/v1 flags helpers, plus **remote** variant fetch. Custom `ServerUrl` / stream URLs that include a path prefix (gateway, regional host, etc.) should now resolve to `{base}/{sdk/...}` instead of dropping the prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1821e521aadc3ac5f7742f35ce454eeb5d907210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->