### PR TITLE
feat(local): require Go 1.22 for tmaxmax/go-sse and cover the SSE adapter

### DIFF
--- a/pkg/experiment/local/stream_adapter_test.go
+++ b/pkg/experiment/local/stream_adapter_test.go
@@ -1,0 +1,163 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// adapterHarness drives the real tmaxmaxEventSource (not the mock) against an
+// httptest server and exposes its callbacks and message channel for assertions.
+type adapterHarness struct {
+	events       chan *sseEvent
+	connected    chan struct{}
+	disconnected chan struct{}
+	subscribeErr chan error
+}
+
+func startAdapter(ctx context.Context, url string, headers map[string]string) *adapterHarness {
+	h := &adapterHarness{
+		events:       make(chan *sseEvent, 8),
+		connected:    make(chan struct{}, 1),
+		disconnected: make(chan struct{}, 1),
+		subscribeErr: make(chan error, 1),
+	}
+	es := newEventSource(&http.Client{}, url, headers)
+	es.OnConnect(func() { h.connected <- struct{}{} })
+	es.OnDisconnect(func() { h.disconnected <- struct{}{} })
+	go func() { h.subscribeErr <- es.SubscribeChanRawWithContext(ctx, h.events) }()
+	return h
+}
+
+func (h *adapterHarness) awaitConnect(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.connected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected OnConnect to fire")
+	}
+}
+
+func (h *adapterHarness) awaitEvent(t *testing.T) *sseEvent {
+	t.Helper()
+	select {
+	case ev := <-h.events:
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an event")
+		return nil
+	}
+}
+
+// sseHandler flushes the given raw SSE frames, then returns (closing the stream).
+func sseHandler(frames ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		for _, f := range frames {
+			fmt.Fprint(w, f)
+			flusher.Flush()
+		}
+	}
+}
+
+// A validated 200 signals connect, keepalive frames survive as a single space
+// byte, data events pass through, and a lost connection fires OnDisconnect.
+func TestAdapterConnectDeliversEventsAndDisconnects(t *testing.T) {
+	srv := httptest.NewServer(sseHandler("data:  \n\n", "data: hello\n\n"))
+	defer srv.Close()
+
+	h := startAdapter(context.Background(), srv.URL, map[string]string{"Authorization": "Api-Key test"})
+	h.awaitConnect(t)
+
+	keepalive := h.awaitEvent(t)
+	assert.Equal(t, []byte{STREAM_KEEP_ALIVE_BYTE}, keepalive.Data, "keepalive should arrive as a single space byte")
+
+	data := h.awaitEvent(t)
+	assert.Equal(t, []byte("hello"), data.Data)
+
+	select {
+	case <-h.disconnected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected OnDisconnect after the server closed the stream")
+	}
+	assert.Error(t, <-h.subscribeErr, "a lost connection should surface an error")
+}
+
+func TestAdapterSendsAuthHeader(t *testing.T) {
+	gotAuth := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth <- r.Header.Get("Authorization")
+		sseHandler("data: x\n\n")(w, r)
+	}))
+	defer srv.Close()
+
+	h := startAdapter(context.Background(), srv.URL, map[string]string{"Authorization": "Api-Key secret"})
+	h.awaitConnect(t)
+	assert.Equal(t, "Api-Key secret", <-gotAuth)
+}
+
+func TestAdapterNon200IsPermanentError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	h := startAdapter(context.Background(), srv.URL, nil)
+	require.Error(t, <-h.subscribeErr)
+	assertNoSignal(t, h.connected, "OnConnect must not fire on a non-200 response")
+	assertNoSignal(t, h.disconnected, "OnDisconnect must not fire when a connection was never established")
+}
+
+// go-sse validates Content-Type: text/event-stream; r3labs did not. This guards
+// that behavior change so a proxy that mangles the content type fails fast
+// rather than hanging on a silently-dead stream.
+func TestAdapterRejectsWrongContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "data: hi\n\n")
+	}))
+	defer srv.Close()
+
+	h := startAdapter(context.Background(), srv.URL, nil)
+	require.Error(t, <-h.subscribeErr)
+	assertNoSignal(t, h.connected, "a non-SSE content type must not be treated as connected")
+}
+
+func TestAdapterContextCancelReturnsCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		fmt.Fprint(w, "data:  \n\n")
+		flusher.Flush()
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h := startAdapter(ctx, srv.URL, nil)
+	h.awaitConnect(t)
+	h.awaitEvent(t)
+
+	cancel()
+	assert.ErrorIs(t, <-h.subscribeErr, context.Canceled)
+	assertNoSignal(t, h.disconnected, "cancellation is not a disconnect")
+}
+
+func assertNoSignal(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal(msg)
+	default:
+	}
+}


### PR DESCRIPTION
### Summary

Follow-up to #48, which was merged before its release mechanics were sorted out. This PR does two things:

**1. Triggers the release that #48 should have produced.** #48 merged as a `refactor(local): ...` squash commit. Under the repo's Angular semantic-release preset, `refactor:` cuts **no release** and doesn't appear in release notes — so the `r3labs/sse` → `tmaxmax/go-sse` swap and the **Go 1.22 minimum bump are currently sitting unreleased on `main`** and would otherwise silently ride the next unrelated `fix:`/`feat:` release. This `feat:` commit forces a proper **minor** release (e.g. `v1.12.0`) whose notes announce the new Go 1.22 requirement.

Shipping the Go-version bump as a **minor**, not a major, is deliberate: the module path is `github.com/amplitude/experiment-go-server` with no `/v2` suffix, so a `v2.0.0` tag would be **un-installable** via `go get` without a full `/v2` module-path migration. Raising the minimum Go version in a minor is standard in the Go ecosystem, and the `go 1.22` directive already gives older toolchains a clear build-time error. (This is why there is intentionally **no** `BREAKING CHANGE` footer here.)

**2. Adds the missing test coverage for the new SSE adapter.** #48's `tmaxmaxEventSource` — the only genuinely new production code — had no direct tests; the existing stream tests all mock the `eventSource` interface. The new `stream_adapter_test.go` drives the **real** adapter against an `httptest` SSE server and asserts:

- a validated 200 signals `OnConnect`, keepalive frames survive as a single space byte, data events pass through, and a lost connection fires `OnDisconnect` + returns an error
- the `Authorization` header is forwarded
- a non-200 response is a permanent error with no `OnConnect`/`OnDisconnect`
- a non-`text/event-stream` content type is rejected — **a behavior change from `r3labs`** (which only checked the status code); consumers behind a content-type-mangling proxy now fail fast instead of hanging on a silently-dead stream
- context cancellation returns `context.Canceled` and is **not** reported as a disconnect

No production code changes. Minimum supported Go remains 1.22.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-go-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: **No.** Raises the minimum Go version to 1.22 (already merged in #48); shipped as a minor release, not a major — see Summary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no runtime or API changes.
> 
> **Overview**
> Adds **`stream_adapter_test.go`**, the first tests that exercise the real **`tmaxmaxEventSource`** (existing stream tests only mock **`eventSource`**). An **`httptest`** harness drives **`SubscribeChanRawWithContext`** against a fake SSE server.
> 
> Coverage includes successful connect, keepalive as a single space byte, data delivery, **`OnDisconnect`** and subscribe error when the server closes, **`Authorization`** forwarding, permanent failure on non-200 without connect/disconnect callbacks, rejection of non-**`text/event-stream`** responses (fail-fast vs legacy **`r3labs`** behavior), and **`context.Canceled`** without treating cancel as disconnect.
> 
> No production code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b8561176fb7d784339b75f4da97d4e22700beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->